### PR TITLE
Prevent legend from moving out of bounding box on redraw when verticalAlign == 'bottom' (see issue #2)

### DIFF
--- a/adapt-chart-to-legend.js
+++ b/adapt-chart-to-legend.js
@@ -31,9 +31,12 @@
           addedHeight = Math.max(this.group.translateY + this.legendHeight - chart.originalChartHeight, 0);
 
           // Move the legend down
-        } else if (this.options.verticalAlign === 'bottom') {
+        } else if (!chart.container.attributes['height-adapted-to-legend'] && this.options.verticalAlign === 'bottom') { // #2
           translateY = this.group.attr('translateY') + this.legendHeight;
           this.group.attr('translateY', translateY);
+
+          chart.container.setAttribute('height-adapted-to-legend', true); // #2
+
           if (this.group.alignAttr) {
             this.group.alignAttr.translateY = translateY;
           }

--- a/adapt-chart-to-legend.js
+++ b/adapt-chart-to-legend.js
@@ -31,11 +31,9 @@
           addedHeight = Math.max(this.group.translateY + this.legendHeight - chart.originalChartHeight, 0);
 
           // Move the legend down
-        } else if (!chart.container.attributes['height-adapted-to-legend'] && this.options.verticalAlign === 'bottom') { // #2
-          translateY = this.group.attr('translateY') + this.legendHeight;
+        } else if (this.options.verticalAlign === 'bottom') { 
+          translateY = chart.originalChartHeight; // #2
           this.group.attr('translateY', translateY);
-
-          chart.container.setAttribute('height-adapted-to-legend', true); // #2
 
           if (this.group.alignAttr) {
             this.group.alignAttr.translateY = translateY;


### PR DESCRIPTION
https://github.com/highcharts/adapt-chart-to-legend/issues/2

("added a condition which prevents adding height more than once")

I've simply updated the PR to a more current version of master.